### PR TITLE
Set execute permission on update script in kafka service deployment

### DIFF
--- a/docker-compose/kafka-kraft/docker-compose.yml
+++ b/docker-compose/kafka-kraft/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
     volumes:
       - ./update_run.sh:/tmp/update_run.sh
-    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else chmod +x /tmp/update_run.sh && /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"


### PR DESCRIPTION
When trying to run the example, I had problems starting the Kafka service.

Error in container: `/bin/sh: bad interpreter: Permission denied`

Setting execution permission for the update script solved the problem.